### PR TITLE
Possible error in gen_matrices_3d.c

### DIFF
--- a/toolbox/mex/gen_matrices_3d.c
+++ b/toolbox/mex/gen_matrices_3d.c
@@ -511,7 +511,7 @@ double boundary_int(double gg[4][3], double bnd_index[4], double ksir[4], \
     
     *valr = sres*side_size*ksitmp_r;  
   }
-  else if (bnd_index[0]==1 && bnd_index[3]==1 && bnd_index[2]==1){ 
+  else if (bnd_index[1]==1 && bnd_index[3]==1 && bnd_index[2]==1){ 
     static double sd4_intf1ff[4][4]={{0.0,0.0,0.0,0.0},\
 				     {0.0,0.0,0.0,0.0},\
 				     {0.0,0.0,0.0,0.0},\


### PR DESCRIPTION
I looks like the last elseif condition in boundary_int is redundant and just a reordering of the 3rd condition, and because of this valr is always 0 for an element where only nodes 1-3 are on the boundary.

I think suggested change would resolve the redundancy and allow for integration over the face 123 which is currently not done.

Although not sure if there's some symmetry at play that allows for evaluation of just faces 012, 031 and 023?